### PR TITLE
Split STAC items by step

### DIFF
--- a/src/stactools/ecmwf_forecast/stac.py
+++ b/src/stactools/ecmwf_forecast/stac.py
@@ -85,8 +85,10 @@ class Parts:
         else:
             return f"{self.step}-{self.format}"
 
+    # mypy complains about  error: Name "datetime.timedelta" is not defined
+    # for offset and forecast_datetime
     @property
-    def offset(self) -> datetime.timedelta:
+    def offset(self):
         v, u = self.step[:-1], self.step[-1]
         offset_value = int(v)
 
@@ -99,7 +101,7 @@ class Parts:
         return offset
 
     @property
-    def forecast_datetime(self) -> datetime.datetime:
+    def forecast_datetime(self):
         return self.reference_datetime + self.offset
 
     @property

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -90,3 +90,25 @@ def test_list_sibling_assets(filename):
         assert item.stream == me.stream
         assert item.type == me.type
         assert item.step != me.step
+
+
+
+def test_split_by_parts():
+    files = [
+        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.grib2',
+        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.index',
+        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.grib2',
+        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.index',
+    ]
+
+    stac.create_item(files)
+
+    with pytest.raises(ValueError, match="different Item ID"):
+        stac.create_item(files, split_by_step=True)
+
+    i0, i1 = stac.create_item(files[:2], split_by_step=True), stac.create_item(files[2:], split_by_step=True)
+    assert i0.properties["ecmwf:step"] == "0h"
+    assert i1.properties["ecmwf:step"] == "3h"
+    assert i0.assets["data"].extra_fields == {}
+    assert i1.datetime == datetime.datetime(2022, 2, 22, 3)
+    assert i1.id.endswith("3h")

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -92,13 +92,12 @@ def test_list_sibling_assets(filename):
         assert item.step != me.step
 
 
-
 def test_split_by_parts():
     files = [
-        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.grib2',
-        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.index',
-        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.grib2',
-        'https://ai4edataeuwest.blob.core.windows.net/ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.index',
+        "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.grib2",
+        "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.index",
+        "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.grib2",
+        "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-3h-enfo-ef.index",
     ]
 
     stac.create_item(files)
@@ -106,7 +105,9 @@ def test_split_by_parts():
     with pytest.raises(ValueError, match="different Item ID"):
         stac.create_item(files, split_by_step=True)
 
-    i0, i1 = stac.create_item(files[:2], split_by_step=True), stac.create_item(files[2:], split_by_step=True)
+    i0, i1 = stac.create_item(files[:2], split_by_step=True), stac.create_item(
+        files[2:], split_by_step=True
+    )
     assert i0.properties["ecmwf:step"] == "0h"
     assert i1.properties["ecmwf:step"] == "3h"
     assert i0.assets["data"].extra_fields == {}


### PR DESCRIPTION
An alternative implementation that splits STAC items by step, in
addition to stream and type.

There are a few knock-on changes:

1. The item-id includes step
2. The asset keys are now "index" and "data", they no longer include the
   step
3. The item `datetime` is now the forecast datetime. We don't set
   `start_datetime` or `end_datetime`.
4. We set ecmwf:step on the item

This isn't the default yet. But I think it will become the default after
I test it out a bit.
