### PR TITLE
Optional resolution

### DIFF
--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -130,6 +130,30 @@ def test_split_by_parts():
     assert i1.id.endswith("3h")
 
 
+@pytest.mark.parametrize(
+    ["files", "resolution"],
+    [
+        (
+            (
+                "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.grib2",
+                "ecmwf/20220222/00z/0p4-beta/enfo/20220222000000-0h-enfo-ef.index",
+            ),
+            "0.40",
+        ),
+        (
+            (
+                "ecmwf/20220222/00z/0p25/enfo/20220222000000-0h-enfo-ef.grib2",
+                "ecmwf/20220222/00z/0p25/enfo/20220222000000-0h-enfo-ef.index",
+            ),
+            "0.25",
+        ),
+    ],
+)
+def test_resolution(files, resolution):
+    result = stac.create_item(files, resolution=resolution)
+    assert result.properties["ecmwf:resolution"] == resolution
+    assert result.id == f"ecmwf-2022-02-22T00-enfo-ef-{resolution}"
+
 
 def test_item_assets():
     collection = stac.create_collection()


### PR DESCRIPTION
Adds an optional `resolution` argument, for handling the current timeframe where both 0.25 and 0.40 resolution data are being produced.