### PR TITLE
Bump version

### DIFF
--- a/src/stactools/ecmwf_forecast/__init__.py
+++ b/src/stactools/ecmwf_forecast/__init__.py
@@ -13,4 +13,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_ecmwfforecast_command)
 
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Bumped the version on main to 0.3.0 to be ahead of https://github.com/stactools-packages/ecmwf-forecast/releases/tag/0.2.0